### PR TITLE
Add SHA-2 check for golang archive

### DIFF
--- a/build_libpostal_rest.sh
+++ b/build_libpostal_rest.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+set -e
+
 curl https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz > go1.6.2.linux-amd64.tar.gz
+
+echo "e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a  go1.6.2.linux-amd64.tar.gz" | sha256sum -c
 
 tar xzf go1.6.2.linux-amd64.tar.gz
 


### PR DESCRIPTION
Minor touch but seemed like best-practice. SHA256 retrieved from https://golang.org/dl/